### PR TITLE
Make ACF field group location args dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,102 @@ Full-width home page design featuring a video banner.
 
 ## Dependencies
 
-This plugin requires [Advanced Custom Fields Pro](https://www.advancedcustomfields.com/pro)
-to be installed and activated.
+This plugin requires [Advanced Custom Fields
+Pro](https://www.advancedcustomfields.com/pro) to be installed and activated.
+
+## Working with ACF
+
+This plugin uses ACF to save user-generated content, and to fetch that content
+from the database. The plugin provides its own ACF field groups.
+
+The `acf/php` directory contains PHP code that registers all the ACF fields that
+the plugin uses. However, ACF field groups created from PHP code will not
+display in the list of field groups in the WordPress admin area. This means that
+the field groups used by this plugin aren't editable using the ACF UI, which
+makes it considerably harder to make changes to ACF field groups.
+
+To make life easier, the `acf/json` directory contains a JSON export of each
+field group used by this plugin. These JSON representations of the ACF field
+groups should have a corresponding PHP version. For example, the file
+`banner.json` is located at `acf/json/banner.json`, and the corresponding PHP
+file is located at `acf/php/banner.php`.
+
+So, how does having a redundant JSON file make it easier to edit ACF? **The JSON
+version can be imported into the development environment. Once imported, the
+field groups will show up in the field group list, and can be edited using the
+ACF UI.**
+
+### Modifying existing field groups
+
+After you've imported a field group using an ACF JSON file and made changes to
+it, you'll need to export the ACF code and save it in the appropriate location
+inside the `acf` directory.
+
+To export, go to the `Custom Fields → Tools` section of the admin area, and
+perform these steps:
+
+1. Export the JSON version, and save it to the correct location in `acf/json`.
+   Unless you are adding a brand new field group, this will involve overwriting
+   one of the existing files in that directory.
+2. Generate the PHP code, and copy it to the clipboard.
+3. Open the appropriate file in the `acf/php` directory and replace the PHP code
+   with what you copied to your clipboard. Make sure not to remove the opening
+   PHP tag or namespace declaration.
+4. Towards the bottom of the file, you'll see an array key called `location`.
+   This `location` array **must** be modified – details
+   [below](#how-to-update-the-location-array).
+
+The PHP and JSON versions of a field group should be identical. If you're
+exporting one, it's a good idea to export the other one too, which should
+prevent them from ever getting out-of-sync.
+
+### How to update the `location` array
+
+The `location` array tells ACF where and when to load the ACF field group. In
+the case of this plugin, we want to load our ACF field groups only when the
+current page is using the template provided by our plugin ("Home Page v2"). If
+a page uses that template, we want our field groups to be displayed.
+
+When the PHP code is generated during export, the `location` array looks
+something like this:
+
+```php
+'location' => array(
+  array(
+    array(
+      'param' => 'page_template',
+      'operator' => '==',
+      'value' => '/path/to/plugin/templates/home-page-v2.php',
+    ),
+  ),
+),
+```
+
+There is a problem with this, though. The value `value` key is a hard-coded path
+which indicates the location of the "Home Page v2" template. The problem is that
+the actual path to this template file will vary in different environments. The
+generated path is local to the development environment, and unless the path is
+the same across all environments, this will break outside of the development
+environment.
+
+If this were to break as I described, you would notice that no ACF field groups
+are shown when the "Home Page v2" template is selected.
+
+To fix this issue, replace the value of the `value` key with the following
+method call:
+
+```php
+'location' => array(
+  array(
+    array(
+      'param' => 'page_template',
+      'operator' => '==',
+      'value' => Template::absolute_path(),
+    ),
+  ),
+),
+```
+
+The call to `Template::absolute_path()` uses WordPress APIs to dynamically build
+the correct path to the template file, and will ensure that the plugin's ACF
+field groups display correctly.

--- a/acf/json/banner.json
+++ b/acf/json/banner.json
@@ -140,7 +140,7 @@
                                 "label": "MP4 Video",
                                 "name": "mp4",
                                 "type": "file",
-                                "instructions": "Recommended size of less than 6 MB.",
+                                "instructions": "Recommended file size of 6 MB or smaller.",
                                 "required": 1,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -159,7 +159,7 @@
                                 "label": "WebM Video",
                                 "name": "webm",
                                 "type": "file",
-                                "instructions": "Recommended size of less than 6 MB.",
+                                "instructions": "Recommended file size of 6 MB or smaller.",
                                 "required": 0,
                                 "conditional_logic": 0,
                                 "wrapper": {
@@ -189,13 +189,13 @@
                                 "return_format": "array",
                                 "preview_size": "medium",
                                 "library": "all",
-                                "min_width": 3840,
-                                "min_height": 2160,
+                                "min_width": "",
+                                "min_height": "",
                                 "min_size": "",
                                 "max_width": "",
                                 "max_height": "",
                                 "max_size": "",
-                                "mime_types": "jpg,jpeg,gif,png"
+                                "mime_types": ""
                             }
                         ]
                     },
@@ -229,7 +229,7 @@
                         "max_width": "",
                         "max_height": "",
                         "max_size": "",
-                        "mime_types": "jpg,jpeg,gif,png"
+                        "mime_types": ""
                     },
                     {
                         "key": "field_60c25aa893f2b",
@@ -355,7 +355,7 @@
                         "name": "button_video_upload",
                         "type": "file",
                         "instructions": "",
-                        "required": 0,
+                        "required": 1,
                         "conditional_logic": [
                             [
                                 {

--- a/acf/json/card.json
+++ b/acf/json/card.json
@@ -57,25 +57,6 @@
                         "button_label": "Add Feature",
                         "sub_fields": [
                             {
-                                "key": "field_60c8faad643bb",
-                                "label": "Card Heading",
-                                "name": "heading",
-                                "type": "text",
-                                "instructions": "",
-                                "required": 1,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "default_value": "",
-                                "placeholder": "",
-                                "prepend": "",
-                                "append": "",
-                                "maxlength": ""
-                            },
-                            {
                                 "key": "field_60d2454e4d44a",
                                 "label": "Card Image",
                                 "name": "image",
@@ -98,6 +79,25 @@
                                 "max_height": "",
                                 "max_size": "",
                                 "mime_types": ""
+                            },
+                            {
+                                "key": "field_60c8faad643bb",
+                                "label": "Card Heading",
+                                "name": "heading",
+                                "type": "text",
+                                "instructions": "",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "placeholder": "",
+                                "prepend": "",
+                                "append": "",
+                                "maxlength": ""
                             },
                             {
                                 "key": "field_60c8fabf643bc",

--- a/acf/php/banner.php
+++ b/acf/php/banner.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Xzito\TrinityHomePageV2;
+
 if( function_exists('acf_add_local_field_group') ):
 
 acf_add_local_field_group(array(
@@ -143,7 +145,7 @@ acf_add_local_field_group(array(
               'label' => 'MP4 Video',
               'name' => 'mp4',
               'type' => 'file',
-              'instructions' => 'Recommended size of less than 6 MB.',
+              'instructions' => 'Recommended file size of 6 MB or smaller.',
               'required' => 1,
               'conditional_logic' => 0,
               'wrapper' => array(
@@ -162,7 +164,7 @@ acf_add_local_field_group(array(
               'label' => 'WebM Video',
               'name' => 'webm',
               'type' => 'file',
-              'instructions' => 'Recommended size of less than 6 MB.',
+              'instructions' => 'Recommended file size of 6 MB or smaller.',
               'required' => 0,
               'conditional_logic' => 0,
               'wrapper' => array(
@@ -192,13 +194,13 @@ acf_add_local_field_group(array(
               'return_format' => 'array',
               'preview_size' => 'medium',
               'library' => 'all',
-              'min_width' => 3840,
-              'min_height' => 2160,
+              'min_width' => '',
+              'min_height' => '',
               'min_size' => '',
               'max_width' => '',
               'max_height' => '',
               'max_size' => '',
-              'mime_types' => 'jpg,jpeg,gif,png',
+              'mime_types' => '',
             ),
           ),
         ),
@@ -232,7 +234,7 @@ acf_add_local_field_group(array(
           'max_width' => '',
           'max_height' => '',
           'max_size' => '',
-          'mime_types' => 'jpg,jpeg,gif,png',
+          'mime_types' => '',
         ),
         array(
           'key' => 'field_60c25aa893f2b',
@@ -358,7 +360,7 @@ acf_add_local_field_group(array(
           'name' => 'button_video_upload',
           'type' => 'file',
           'instructions' => '',
-          'required' => 0,
+          'required' => 1,
           'conditional_logic' => array(
             array(
               array(
@@ -444,7 +446,7 @@ acf_add_local_field_group(array(
       array(
         'param' => 'page_template',
         'operator' => '==',
-        'value' => '/var/www/app/content/mu-plugins/trinity-home-page-v2/templates/home-page-v2.php',
+        'value' => Template::absolute_path(),
       ),
     ),
   ),

--- a/acf/php/card.php
+++ b/acf/php/card.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Xzito\TrinityHomePageV2;
+
 if( function_exists('acf_add_local_field_group') ):
 
 acf_add_local_field_group(array(
@@ -60,25 +62,6 @@ acf_add_local_field_group(array(
           'button_label' => 'Add Feature',
           'sub_fields' => array(
             array(
-              'key' => 'field_60c8faad643bb',
-              'label' => 'Card Heading',
-              'name' => 'heading',
-              'type' => 'text',
-              'instructions' => '',
-              'required' => 1,
-              'conditional_logic' => 0,
-              'wrapper' => array(
-                'width' => '50',
-                'class' => '',
-                'id' => '',
-              ),
-              'default_value' => '',
-              'placeholder' => '',
-              'prepend' => '',
-              'append' => '',
-              'maxlength' => '',
-            ),
-            array(
               'key' => 'field_60d2454e4d44a',
               'label' => 'Card Image',
               'name' => 'image',
@@ -103,6 +86,25 @@ acf_add_local_field_group(array(
               'mime_types' => '',
             ),
             array(
+              'key' => 'field_60c8faad643bb',
+              'label' => 'Card Heading',
+              'name' => 'heading',
+              'type' => 'text',
+              'instructions' => '',
+              'required' => 1,
+              'conditional_logic' => 0,
+              'wrapper' => array(
+                'width' => '',
+                'class' => '',
+                'id' => '',
+              ),
+              'default_value' => '',
+              'placeholder' => '',
+              'prepend' => '',
+              'append' => '',
+              'maxlength' => '',
+            ),
+            array(
               'key' => 'field_60c8fabf643bc',
               'label' => 'Feature',
               'name' => 'post',
@@ -111,7 +113,7 @@ acf_add_local_field_group(array(
               'required' => 1,
               'conditional_logic' => 0,
               'wrapper' => array(
-                'width' => '50',
+                'width' => '',
                 'class' => '',
                 'id' => '',
               ),
@@ -138,7 +140,7 @@ acf_add_local_field_group(array(
       array(
         'param' => 'page_template',
         'operator' => '==',
-        'value' => '/var/www/app/content/mu-plugins/trinity-home-page-v2/templates/home-page-v2.php',
+        'value' => Template::absolute_path(),
       ),
     ),
   ),

--- a/acf/php/showcase.php
+++ b/acf/php/showcase.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Xzito\TrinityHomePageV2;
+
 if( function_exists('acf_add_local_field_group') ):
 
 acf_add_local_field_group(array(
@@ -110,7 +112,7 @@ acf_add_local_field_group(array(
       array(
         'param' => 'page_template',
         'operator' => '==',
-        'value' => '/var/www/app/content/mu-plugins/trinity-home-page-v2/templates/home-page-v2.php',
+        'value' => Template::absolute_path(),
       ),
     ),
   ),

--- a/src/Editor.php
+++ b/src/Editor.php
@@ -2,8 +2,6 @@
 
 namespace Xzito\TrinityHomePageV2;
 
-use Xzito\TrinityHomePageV2\Template;
-
 class Editor {
   public static function remove_support() {
     global $post;

--- a/src/Template.php
+++ b/src/Template.php
@@ -18,6 +18,10 @@ class Template {
     return (new self())->using_template($post);
   }
 
+  public static function absolute_path() {
+    return (new self())->path();
+  }
+
   public function __construct() { }
 
   public function register_template($page_templates) {


### PR DESCRIPTION
Allow the ACF field groups defined in `acf/php/**` to define the ACF
location conditions dynamically. Effectively, the generated PHP code
contains a hard-coded path, but we need the path to be set dynamically.

Also, update the `README.md` to explain why this path needs to be set
dynamically, and how the behavior is implemented. For more information
about this, take a look at the documentation I added – the section is
called "Working with ACF".